### PR TITLE
Reload all namespaces in dev and add cljfmt

### DIFF
--- a/src/leiningen/new/http_kit/middleware.clj
+++ b/src/leiningen/new/http_kit/middleware.clj
@@ -2,6 +2,7 @@
     (:use [compojure.core :only [GET POST DELETE PUT PATCH]]
           [clojure.tools.logging :only [debug error info]]
           [{{sanitized-ns}}.config :as conf]
+          [ring.middleware.reload :only [wrap-reload]]
           [clojure.data.json :only [write-str]]))
 
 (defn wrap-failsafe [handler]
@@ -27,9 +28,7 @@
 
 (defn wrap-reload-in-dev [handler]
   (if (= (conf/cfg :profile) :dev)
-    (fn [req]
-      (require :reload '{{sanitized-ns}}.tmpls) ; reload templates
-      (handler req))
+    (wrap-reload handler)
     handler))
 
 (defn json-response [resp]

--- a/src/leiningen/new/http_kit/project.clj
+++ b/src/leiningen/new/http_kit/project.clj
@@ -7,10 +7,12 @@
   :aot [{{sanitized-ns}}.main]
   :uberjar-name "{{sanitized-ns}}-standalone.jar"
   ;; :plugins [[lein-swank "1.4.4"]]
+  :plugins [[lein-cljfmt "0.3.0"]]
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [org.clojure/tools.cli "0.2.2"]
                  [compojure "1.1.5"]
                  [ring/ring-core "1.1.8"]
+                 [ring/ring-devel "1.4.0"]
 
                  [org.clojure/data.json "0.2.1"]
 


### PR DESCRIPTION
Instead of just reloading `tmpls` I thought it would be useful to reload all namespaces in dev.

Also added the tool cljfmt. Can add it as a comment instead if you prefer.